### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -16,6 +16,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   private
 
   def item_params

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,6 +2,7 @@ class Item < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :user
   has_one_attached :image
+  has_one :purchase
 
   belongs_to :category
   belongs_to :status

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -1,0 +1,4 @@
+class Purchase < ApplicationRecord
+  belongs_to :user
+  belongs_to :item
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_many :items
+  has_many :purchases
 
   PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i.freeze
   validates_format_of :password, with: PASSWORD_REGEX, message: 'Include both letters and numbers'

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,16 +129,16 @@
       <% if @items != [] %>
       <li class='list'>
         <% @items.each do |item| %>
-          <%= link_to "#" do %>
+          <%= link_to item_path(item.id) do %>
           <div class='item-img-content'>
             <%= image_tag item.image, class: "item-img" %>
             
             <%# 商品が売れていればsold outを表示しましょう %>
-            <%# <% if item.purchase.item_id != '' %>
-            <%# <div class='sold-out'>
+            <% if item.purchase != nil %>
+            <div class='sold-out'>
               <span>Sold Out!!</span>
-            </div> %>
-            <%# <% end %>
+            </div>
+            <% end %>
             <%# //商品が売れていればsold outを表示しましょう %>
 
           </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,66 +4,71 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.title %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class='sold-out'>
-        <span>Sold Out!!</span>
-      </div>
+      <% if @item.purchase != nil %>
+        <div class='sold-out'>
+          <span>Sold Out!!</span>
+        </div>
+      <% end %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= "¥ #{@item.price.to_s(:delimited)}" %>
       </span>
       <span class="item-postage">
-        <%= '配送料負担' %>
+        <%= @item.shipping.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
+    <% if user_signed_in? && (current_user.id == @item.user_id) %>
+      <% if @item.purchase == nil %>
+      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+      <% end %>
+    <% elsif user_signed_in? && (current_user.id != @item.user_id) %>
+      <%# 商品が売れていない場合はこちらを表示しましょう %>
+      <% if @item.purchase == nil %>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+      <% end %>
+      <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <% end %>
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.text %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.day.name %></td>
         </tr>
       </tbody>
     </table>
@@ -102,7 +107,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:index, :new, :create] 
+  resources :items, only: [:index, :new, :create, :show]
 end

--- a/db/migrate/20201114075955_create_purchases.rb
+++ b/db/migrate/20201114075955_create_purchases.rb
@@ -1,0 +1,9 @@
+class CreatePurchases < ActiveRecord::Migration[6.0]
+  def change
+    create_table :purchases do |t|
+      t.references :user,           null: false, foreign_key: true
+      t.references :item,           null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_11_140103) do
+ActiveRecord::Schema.define(version: 2020_11_14_075955) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -48,6 +48,15 @@ ActiveRecord::Schema.define(version: 2020_11_11_140103) do
     t.index ["user_id"], name: "index_items_on_user_id"
   end
 
+  create_table "purchases", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["item_id"], name: "index_purchases_on_item_id"
+    t.index ["user_id"], name: "index_purchases_on_user_id"
+  end
+
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -68,4 +77,6 @@ ActiveRecord::Schema.define(version: 2020_11_11_140103) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "items", "users"
+  add_foreign_key "purchases", "items"
+  add_foreign_key "purchases", "users"
 end

--- a/spec/factories/purchases.rb
+++ b/spec/factories/purchases.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :purchase do
+  end
+end

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Purchase, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## What
- 商品詳細ページの実装
- purchaseモデル（購入履歴）の作成
- 購入済の場合のsoldoutの実装

## Why
商品詳細表示機能の実装のため

## 機能の様子について（Gyazo）
- ログイン状態の出品者のみ、「編集・削除ボタン」が表示される
https://gyazo.com/6ce99de070c11be75150e6c856df561f
- ログイン状態の出品者でも、売却済みの商品に対しては「編集・削除ボタン」が表示されない
https://gyazo.com/877b1fc0249703c9ded70bfe3dd737b5
- ログイン状態の出品者以外のユーザーのみ、「購入画面に進むボタン」が表示されること
https://gyazo.com/43bec38f6073336b4cb77aff76f5d398
- ログアウト状態のユーザーでも、商品詳細表示ページを閲覧できること
- ログアウト状態のユーザーには、「編集・削除・購入画面に進むボタン」が表示されないこと
https://gyazo.com/25d99994de8b6611e22ff2aa44678c9c
